### PR TITLE
Switch from IPFS to ImageKit for image uploads

### DIFF
--- a/components/nft/collection/AddImageToCollectionModal.vue
+++ b/components/nft/collection/AddImageToCollectionModal.vue
@@ -5,7 +5,7 @@
       <p>Upload additional image (and then click Submit below):</p>
       <FileUploadInput
         btnCls="btn btn-primary"
-        storageType="ipfs"
+        storageType="imagekit"
         :maxFileSize="$config.fileUploadSizeLimit"
         @processUploadedFileUrl="insertImageLink"
       />

--- a/components/nft/collection/ChangeCollectionPreviewModal.vue
+++ b/components/nft/collection/ChangeCollectionPreviewModal.vue
@@ -6,7 +6,7 @@
       <FileUploadInput
         btnCls="btn btn-primary"
         :maxFileSize="$config.fileUploadSizeLimit"
-        storageType="ipfs"
+        storageType="imagekit"
         @processUploadedFileUrl="insertImageLink"
       />
       <p class="mt-3">Or paste image link here:</p>

--- a/components/profile/PunkProfile.vue
+++ b/components/profile/PunkProfile.vue
@@ -272,7 +272,7 @@
         @processFileUrl="insertImage"
         title="Change profile image"
         infoText="Upload a new profile picture."
-        storageType="ipfs"
+        storageType="imagekit"
         :componentId="$.uid"
         :maxFileSize="$config.fileUploadSizeLimit"
       />

--- a/pages/nft/collection.vue
+++ b/pages/nft/collection.vue
@@ -315,7 +315,7 @@
               <change-collection-preview-modal
                 :cAddress="selectedNft.address"
                 :mdAddress="selectedNft.mdAddress"
-                storageType="ipfs"
+                storageType="imagekit"
                 @saveCollection="saveCollection"
               ></change-collection-preview-modal>
             </div>
@@ -330,7 +330,7 @@
                   <add-image-to-collection-modal
                     :cAddress="selectedNft.address"
                     :mdAddress="selectedNft.mdAddress"
-                    storageType="ipfs"
+                    storageType="imagekit"
                     @saveCollection="saveCollection"
                   ></add-image-to-collection-modal>
                 </div>

--- a/pages/nft/create.vue
+++ b/pages/nft/create.vue
@@ -260,7 +260,7 @@
         @processFileUrl="insertImage"
         title="Upload your NFT image"
         infoText="Upload the NFT image."
-        storageType="ipfs"
+        storageType="imagekit"
         :componentId="$.uid"
         :maxFileSize="$config.fileUploadSizeLimit"
       />


### PR DESCRIPTION
IPFS (Thirdweb) has been quite unreliable lately, so this PR switches to ImageKit for image uploads.

This simple change can be easily reversed back to IPFS if needed at any time in the future.