### PR TITLE
The referrer issue with swapping tokens fixed

### DIFF
--- a/components/swap/SwapTokensModal.vue
+++ b/components/swap/SwapTokensModal.vue
@@ -123,8 +123,7 @@ export default {
 
       const inputTokenAmountWei = ethers.utils.parseUnits(this.inputTokenAmount, this.inputToken?.decimals);
 
-      // TODO: address zero because IggySwapRouter has an error if referrer is passed
-      const referrer = ethers.constants.AddressZero; // fetchReferrer(window);
+      const referrer = fetchReferrer(window);
 
       try {
         const tx = await swapTokens(

--- a/utils/simpleSwapUtils.js
+++ b/utils/simpleSwapUtils.js
@@ -101,11 +101,11 @@ export function swapTokens(signer, receiver, inputToken, outputToken, amountIn, 
     // else if at least one of the tokens is ERC-20 token (but not wrapped native token)
     const routerAbi = [
       "function swapExactTokensForTokens(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) external returns (uint[] memory amounts)",
-      "function swapExactTokensForTokensWithReferrer(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) external returns (uint[] memory amounts)",
+      "function swapExactTokensForTokensWithReferrer(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline, address referrer) external returns (uint[] memory amounts)",
       "function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline) external payable returns (uint[] memory amounts)",
-      "function swapExactETHForTokensWithReferrer(uint amountOutMin, address[] calldata path, address to, uint deadline) external payable returns (uint[] memory amounts)",
+      "function swapExactETHForTokensWithReferrer(uint amountOutMin, address[] calldata path, address to, uint deadline, address referrer) external payable returns (uint[] memory amounts)",
       "function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) external returns (uint[] memory amounts)",
-      "function swapExactTokensForETHWithReferrer(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) external returns (uint[] memory amounts)",
+      "function swapExactTokensForETHWithReferrer(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline, address referrer) external returns (uint[] memory amounts)",
     ];
 
     const routerContract = new ethers.Contract(routerAddress, routerAbi, provider);


### PR DESCRIPTION
This pull request fixes the issue with passing a non-zero referrer address to the swap function.

Previously, if a non-zero referrer address was passed as input, the swap failed.

It turned out that the referrer address attribute was missing in required function headers in the interface.

The referrer address attribute has been added in this PR, and now swaps work without any problem even if there's a non-zero referrer address passed as an input.